### PR TITLE
Fixes a dependency error  when wrong autoload file is used

### DIFF
--- a/notification.php
+++ b/notification.php
@@ -22,7 +22,7 @@ if ( ! defined( 'NOTIFICATION_DIR' ) ) {
 /**
  * Composer autoload
  */
-require_once( 'vendor/autoload.php' );
+require_once( plugin_dir_path( __FILE__ ).'/vendor/autoload.php' );
 
 /**
  * Check minimum requirements of the plugin

--- a/notification.php
+++ b/notification.php
@@ -22,7 +22,7 @@ if ( ! defined( 'NOTIFICATION_DIR' ) ) {
 /**
  * Composer autoload
  */
-require_once( plugin_dir_path( __FILE__ ).'/vendor/autoload.php' );
+require_once( NOTIFICATION_DIR . '/vendor/autoload.php' );
 
 /**
  * Check minimum requirements of the plugin

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,9 @@ Yes, you can. [See the detailed guide](https://notification.underdev.it/includin
 
 == Changelog ==
 
+= Next release =
+* [Fixed] Composer autoload file thanks to @jclausen
+
 = 3.1.1 =
 * [Fixed] Bug with directories/files names, thanks to Gregory Rick
 


### PR DESCRIPTION
When running a Wordpress site with a root-level `vendor` directory and composer installation, the wrong `autoload.php` file is loaded by the plugin.   This results in the fatal error:

```
PHP Fatal error:  Class 'Minimum_Requirements' not found in ~/Sites/mysite/wp-content/plugins/notification/notification.php on line 34
```

Commit fixes error by using the absolute path, previously defined, to the composer autoload.